### PR TITLE
Force the oauth redirect to use the secure base url for the admin url.

### DIFF
--- a/app/code/community/Coinbase/Coinbase/controllers/RedirectController.php
+++ b/app/code/community/Coinbase/Coinbase/controllers/RedirectController.php
@@ -28,7 +28,7 @@ class Coinbase_Coinbase_RedirectController extends Mage_Core_Controller_Front_Ac
     
     public function oauthAction() {
 
-        $redirectUrlNoCode = Mage::getUrl("adminhtml/coinbaseoauth/redirect");
+        $redirectUrlNoCode = Mage::getUrl("adminhtml/coinbaseoauth/redirect", array('_secure' => 1));
         $this->_redirectUrl($redirectUrlNoCode . "key/$_GET[key]/?code=$_GET[code]&key=$_GET[key]");
     }
 


### PR DESCRIPTION
When the admin panel is protected by SSL Magento redirects to the secure url however the key and code params are stripped which causes the oauth link to fail as the code is no longer available.
