### PR TITLE
Removed custom_secure param from button creation

### DIFF
--- a/app/code/community/Coinbase/Coinbase/Model/PaymentMethod.php
+++ b/app/code/community/Coinbase/Coinbase/Model/PaymentMethod.php
@@ -97,10 +97,9 @@ class Coinbase_Coinbase_Model_PaymentMethod extends Mage_Payment_Model_Method_Ab
             'callback_url' => Mage::getUrl('coinbase_coinbase'). 'callback/callback/?secret=' . $callbackSecret,
             'success_url' => $successUrl,
             'cancel_url' => $cancelUrl,
-            'info_url' => Mage::getBaseUrl(),
-            'custom_secure' => true,
+            'info_url' => Mage::getBaseUrl()
           );
-      
+
       // Generate the code
       try {
         $code = $coinbase->createButton($name, $amount, $currency, $custom, $params)->button->code;


### PR DESCRIPTION
Fixes #11 (The cancel link on the Coinbase payment page doesn't work)

Is there any reason why we would need to hide the magento order id from the customer?
